### PR TITLE
ci: fix wait-on-check-action argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: main
-          check-name: pytest
+          check-name: test
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Check out the repo


### PR DESCRIPTION
## 概要 / Overview
lewagon/wait-on-check-actionの引数が間違っていたので修正。

## 詳細 / Details
- check-nameをpytestからtestにした、どうやらjobs内の模様

## 参考 / References
<!-- 参考情報/リンク（懸念点や注意点などあれば記載） -->